### PR TITLE
調味料の賞味期限管理機能の追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,10 @@
 <body>
     <header>
         <h1>🍳 料理レシピアプリ</h1>
-        <button id="addRecipeBtn" class="btn-primary">新しいレシピを追加</button>
+        <div style="display: flex; gap: 1rem;">
+            <a href="seasoning.html" class="btn-secondary" style="text-decoration: none; display: inline-flex; align-items: center;">🧂 調味料管理</a>
+            <button id="addRecipeBtn" class="btn-primary">新しいレシピを追加</button>
+        </div>
     </header>
 
     <main>

--- a/seasoning.css
+++ b/seasoning.css
@@ -1,0 +1,362 @@
+/* 調味料管理ページ専用スタイル */
+
+/* ヘッダーアクション */
+.header-actions {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+/* フィルターセクション */
+.filter-section {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    padding: 1.5rem;
+    border-radius: 20px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.06);
+    margin-bottom: 2rem;
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.filter-btn {
+    padding: 0.7rem 1.5rem;
+    border: 2px solid #e8e8f0;
+    border-radius: 20px;
+    background: white;
+    color: #546e7a;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.filter-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+
+.filter-btn.active {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border-color: transparent;
+}
+
+/* 統計セクション */
+.stats-section {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1.2rem;
+    margin-bottom: 2rem;
+}
+
+.stat-card {
+    background: rgba(255, 255, 255, 0.98);
+    border-radius: 16px;
+    padding: 1.5rem;
+    text-align: center;
+    box-shadow: 0 6px 20px rgba(0,0,0,0.06);
+    transition: all 0.3s ease;
+}
+
+.stat-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+}
+
+.stat-number {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+}
+
+.stat-label {
+    font-size: 0.9rem;
+    color: #607d8b;
+    font-weight: 500;
+}
+
+.expired-stat .stat-number {
+    color: #ff4757;
+}
+
+.warning-stat .stat-number {
+    color: #ffa502;
+}
+
+.safe-stat .stat-number {
+    color: #26de81;
+}
+
+.total-stat .stat-number {
+    color: #5f27cd;
+}
+
+/* 調味料リスト */
+.seasoning-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+/* 調味料カード */
+.seasoning-card {
+    background: rgba(255, 255, 255, 0.98);
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 6px 20px rgba(0,0,0,0.06);
+    transition: all 0.3s ease;
+    border: 2px solid transparent;
+    position: relative;
+    overflow: hidden;
+}
+
+.seasoning-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #26de81 0%, #26de81 100%);
+    transition: all 0.3s ease;
+}
+
+.seasoning-card.expired {
+    border-color: #ffe5e5;
+    background: #fff5f5;
+}
+
+.seasoning-card.expired::before {
+    background: linear-gradient(90deg, #ff4757 0%, #ff6b7a 100%);
+}
+
+.seasoning-card.warning {
+    border-color: #fff4e5;
+    background: #fffaf0;
+}
+
+.seasoning-card.warning::before {
+    background: linear-gradient(90deg, #ffa502 0%, #ffcc29 100%);
+}
+
+.seasoning-card.safe::before {
+    background: linear-gradient(90deg, #26de81 0%, #4ecca3 100%);
+}
+
+.seasoning-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 12px 30px rgba(0,0,0,0.12);
+}
+
+.seasoning-header {
+    margin-bottom: 1rem;
+}
+
+.seasoning-name {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: #2c3e50;
+    margin-bottom: 0.5rem;
+}
+
+.seasoning-category {
+    display: inline-block;
+    background: linear-gradient(135deg, #e0f7fa 0%, #e1f5fe 100%);
+    color: #00838f;
+    padding: 0.3rem 0.8rem;
+    border-radius: 15px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.seasoning-details {
+    margin: 1rem 0;
+}
+
+.detail-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.8rem;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #f0f0f5;
+}
+
+.detail-row:last-child {
+    border-bottom: none;
+}
+
+.detail-label {
+    font-size: 0.85rem;
+    color: #607d8b;
+    font-weight: 500;
+}
+
+.detail-value {
+    font-size: 0.9rem;
+    color: #2c3e50;
+    font-weight: 600;
+}
+
+.expiry-date {
+    font-size: 1rem;
+}
+
+.expired .expiry-date {
+    color: #ff4757;
+}
+
+.warning .expiry-date {
+    color: #ffa502;
+}
+
+.safe .expiry-date {
+    color: #26de81;
+}
+
+/* 残量インジケーター */
+.quantity-indicator {
+    width: 100%;
+    height: 8px;
+    background: #f0f0f5;
+    border-radius: 10px;
+    overflow: hidden;
+    margin: 0.5rem 0;
+}
+
+.quantity-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #56ab2f 0%, #a8e063 100%);
+    border-radius: 10px;
+    transition: width 0.3s ease;
+}
+
+.quantity-fill.low {
+    background: linear-gradient(90deg, #ff4757 0%, #ff6b7a 100%);
+}
+
+.quantity-fill.medium {
+    background: linear-gradient(90deg, #ffa502 0%, #ffcc29 100%);
+}
+
+/* アクションボタン */
+.seasoning-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.btn-edit-seasoning,
+.btn-delete-seasoning {
+    flex: 1;
+    padding: 0.6rem;
+    border-radius: 10px;
+    border: none;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.btn-edit-seasoning {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+}
+
+.btn-edit-seasoning:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+}
+
+.btn-delete-seasoning {
+    background: #f8f9fa;
+    color: #6c757d;
+    border: 2px solid #e9ecef;
+}
+
+.btn-delete-seasoning:hover {
+    background: #fff;
+    border-color: #ff4757;
+    color: #ff4757;
+}
+
+/* 空の状態 */
+.empty-state {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 4rem 2rem;
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 20px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.06);
+}
+
+.empty-state h3 {
+    font-size: 1.8rem;
+    color: #90a4ae;
+    margin-bottom: 1rem;
+}
+
+.empty-state p {
+    color: #607d8b;
+    font-size: 1.1rem;
+}
+
+/* 期限表示の特別スタイル */
+.days-remaining {
+    display: inline-block;
+    padding: 0.2rem 0.6rem;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    margin-left: 0.5rem;
+}
+
+.days-remaining.expired {
+    background: #ffe5e5;
+    color: #ff4757;
+}
+
+.days-remaining.warning {
+    background: #fff4e5;
+    color: #ffa502;
+}
+
+.days-remaining.safe {
+    background: #e5f9f0;
+    color: #26de81;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+    .header-actions {
+        flex-direction: column;
+        width: 100%;
+        gap: 0.5rem;
+    }
+
+    .header-actions .btn-secondary,
+    .header-actions .btn-primary {
+        width: 100%;
+        text-align: center;
+    }
+
+    .filter-section {
+        justify-content: stretch;
+    }
+
+    .filter-btn {
+        flex: 1;
+        min-width: 100px;
+    }
+
+    .stats-section {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .seasoning-list {
+        grid-template-columns: 1fr;
+    }
+}

--- a/seasoning.html
+++ b/seasoning.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>調味料管理 - 料理レシピアプリ</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="seasoning.css">
+</head>
+<body>
+    <header>
+        <h1>🧂 調味料管理</h1>
+        <div class="header-actions">
+            <a href="index.html" class="btn-secondary">レシピ一覧へ</a>
+            <button id="addSeasoningBtn" class="btn-primary">調味料を追加</button>
+        </div>
+    </header>
+
+    <main>
+        <!-- フィルターセクション -->
+        <div class="filter-section">
+            <button class="filter-btn active" data-filter="all">すべて</button>
+            <button class="filter-btn" data-filter="expired">期限切れ</button>
+            <button class="filter-btn" data-filter="warning">期限間近</button>
+            <button class="filter-btn" data-filter="safe">期限まで余裕</button>
+        </div>
+
+        <!-- 統計情報 -->
+        <div class="stats-section">
+            <div class="stat-card expired-stat">
+                <div class="stat-number" id="expiredCount">0</div>
+                <div class="stat-label">期限切れ</div>
+            </div>
+            <div class="stat-card warning-stat">
+                <div class="stat-number" id="warningCount">0</div>
+                <div class="stat-label">期限間近</div>
+            </div>
+            <div class="stat-card safe-stat">
+                <div class="stat-number" id="safeCount">0</div>
+                <div class="stat-label">期限まで余裕</div>
+            </div>
+            <div class="stat-card total-stat">
+                <div class="stat-number" id="totalCount">0</div>
+                <div class="stat-label">合計</div>
+            </div>
+        </div>
+
+        <!-- 調味料一覧 -->
+        <div id="seasoningList" class="seasoning-list">
+            <!-- 調味料カードがここに表示されます -->
+        </div>
+    </main>
+
+    <!-- 調味料追加・編集モーダル -->
+    <div id="seasoningModal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <h2 id="modalTitle">調味料を追加</h2>
+
+            <form id="seasoningForm">
+                <div class="form-group">
+                    <label for="seasoningName">調味料名:</label>
+                    <input type="text" id="seasoningName" required placeholder="例: 醤油、味噌、オリーブオイル">
+                </div>
+
+                <div class="form-group">
+                    <label for="seasoningCategory">カテゴリ:</label>
+                    <select id="seasoningCategory" required>
+                        <option value="">選択してください</option>
+                        <option value="液体調味料">液体調味料</option>
+                        <option value="粉末・顆粒">粉末・顆粒</option>
+                        <option value="ペースト">ペースト</option>
+                        <option value="油">油</option>
+                        <option value="香辛料">香辛料</option>
+                        <option value="その他">その他</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label for="expiryDate">賞味期限:</label>
+                    <input type="date" id="expiryDate" required>
+                </div>
+
+                <div class="form-group">
+                    <label for="openedDate">開封日（任意）:</label>
+                    <input type="date" id="openedDate">
+                </div>
+
+                <div class="form-group">
+                    <label for="quantity">残量:</label>
+                    <select id="quantity">
+                        <option value="100">満タン (100%)</option>
+                        <option value="75">3/4 (75%)</option>
+                        <option value="50">半分 (50%)</option>
+                        <option value="25">1/4 (25%)</option>
+                        <option value="10">残りわずか (10%)</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label for="location">保管場所:</label>
+                    <input type="text" id="location" placeholder="例: 冷蔵庫、調味料棚、パントリー">
+                </div>
+
+                <div class="form-group">
+                    <label for="notes">メモ:</label>
+                    <textarea id="notes" rows="3" placeholder="例: 料理に使う頻度、特別な保存方法など"></textarea>
+                </div>
+
+                <div class="form-buttons">
+                    <button type="submit" class="btn-primary">保存</button>
+                    <button type="button" id="cancelBtn" class="btn-secondary">キャンセル</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <script src="seasoning.js"></script>
+</body>
+</html>

--- a/seasoning.js
+++ b/seasoning.js
@@ -1,0 +1,420 @@
+// 調味料データを保存する配列
+let seasonings = [];
+let editingSeasoningId = null;
+
+// DOM要素を取得
+const addSeasoningBtn = document.getElementById('addSeasoningBtn');
+const seasoningModal = document.getElementById('seasoningModal');
+const seasoningForm = document.getElementById('seasoningForm');
+const seasoningList = document.getElementById('seasoningList');
+const closeBtn = document.querySelector('.close');
+const cancelBtn = document.getElementById('cancelBtn');
+const modalTitle = document.getElementById('modalTitle');
+
+// 統計要素
+const expiredCount = document.getElementById('expiredCount');
+const warningCount = document.getElementById('warningCount');
+const safeCount = document.getElementById('safeCount');
+const totalCount = document.getElementById('totalCount');
+
+// フィルターボタン
+const filterButtons = document.querySelectorAll('.filter-btn');
+
+// 現在のフィルター状態
+let currentFilter = 'all';
+
+// ページ読み込み時の初期化
+document.addEventListener('DOMContentLoaded', function() {
+    loadSeasonings();
+    displaySeasonings();
+    updateStatistics();
+    setupEventListeners();
+
+    // 期限チェックと通知
+    checkExpiredSeasonings();
+});
+
+// イベントリスナーの設定
+function setupEventListeners() {
+    // モーダル開閉
+    addSeasoningBtn.addEventListener('click', openAddModal);
+    closeBtn.addEventListener('click', closeModal);
+    cancelBtn.addEventListener('click', closeModal);
+
+    // モーダル外クリックで閉じる
+    window.addEventListener('click', function(e) {
+        if (e.target === seasoningModal) {
+            closeModal();
+        }
+    });
+
+    // フォーム送信
+    seasoningForm.addEventListener('submit', handleFormSubmit);
+
+    // フィルターボタン
+    filterButtons.forEach(btn => {
+        btn.addEventListener('click', function() {
+            filterButtons.forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            currentFilter = btn.dataset.filter;
+            displaySeasonings();
+        });
+    });
+}
+
+// ローカルストレージから調味料を読み込み
+function loadSeasonings() {
+    const savedSeasonings = localStorage.getItem('seasonings');
+    if (savedSeasonings) {
+        seasonings = JSON.parse(savedSeasonings);
+    }
+}
+
+// ローカルストレージに調味料を保存
+function saveSeasonings() {
+    localStorage.setItem('seasonings', JSON.stringify(seasonings));
+}
+
+// 新規追加モーダルを開く
+function openAddModal() {
+    editingSeasoningId = null;
+    modalTitle.textContent = '調味料を追加';
+    seasoningForm.reset();
+
+    // デフォルト値を設定
+    document.getElementById('quantity').value = '100';
+
+    seasoningModal.style.display = 'block';
+    document.body.style.overflow = 'hidden';
+}
+
+// 編集モーダルを開く
+function openEditModal(seasoningId) {
+    editingSeasoningId = seasoningId;
+    modalTitle.textContent = '調味料を編集';
+
+    const seasoning = seasonings.find(s => s.id === seasoningId);
+    if (seasoning) {
+        document.getElementById('seasoningName').value = seasoning.name;
+        document.getElementById('seasoningCategory').value = seasoning.category;
+        document.getElementById('expiryDate').value = seasoning.expiryDate;
+        document.getElementById('openedDate').value = seasoning.openedDate || '';
+        document.getElementById('quantity').value = seasoning.quantity || '100';
+        document.getElementById('location').value = seasoning.location || '';
+        document.getElementById('notes').value = seasoning.notes || '';
+    }
+
+    seasoningModal.style.display = 'block';
+    document.body.style.overflow = 'hidden';
+}
+
+// モーダルを閉じる
+function closeModal() {
+    seasoningModal.style.display = 'none';
+    document.body.style.overflow = 'auto';
+    editingSeasoningId = null;
+    seasoningForm.reset();
+}
+
+// フォーム送信処理
+function handleFormSubmit(e) {
+    e.preventDefault();
+
+    const formData = {
+        name: document.getElementById('seasoningName').value.trim(),
+        category: document.getElementById('seasoningCategory').value,
+        expiryDate: document.getElementById('expiryDate').value,
+        openedDate: document.getElementById('openedDate').value || null,
+        quantity: parseInt(document.getElementById('quantity').value) || 100,
+        location: document.getElementById('location').value.trim(),
+        notes: document.getElementById('notes').value.trim()
+    };
+
+    if (editingSeasoningId) {
+        // 編集の場合
+        updateSeasoning(editingSeasoningId, formData);
+    } else {
+        // 新規追加の場合
+        addSeasoning(formData);
+    }
+
+    closeModal();
+}
+
+// 調味料を追加
+function addSeasoning(seasoningData) {
+    const seasoning = {
+        id: Date.now().toString(),
+        ...seasoningData,
+        createdAt: new Date().toISOString()
+    };
+
+    seasonings.unshift(seasoning);
+    saveSeasonings();
+    displaySeasonings();
+    updateStatistics();
+    showNotification('調味料が追加されました！', 'success');
+
+    // 期限チェック
+    checkExpiredSeasonings();
+}
+
+// 調味料を更新
+function updateSeasoning(seasoningId, seasoningData) {
+    const index = seasonings.findIndex(s => s.id === seasoningId);
+    if (index !== -1) {
+        seasonings[index] = {
+            ...seasonings[index],
+            ...seasoningData,
+            updatedAt: new Date().toISOString()
+        };
+        saveSeasonings();
+        displaySeasonings();
+        updateStatistics();
+        showNotification('調味料が更新されました！', 'success');
+
+        // 期限チェック
+        checkExpiredSeasonings();
+    }
+}
+
+// 調味料を削除
+function deleteSeasoning(seasoningId) {
+    if (confirm('この調味料を削除しますか？この操作は元に戻せません。')) {
+        seasonings = seasonings.filter(s => s.id !== seasoningId);
+        saveSeasonings();
+        displaySeasonings();
+        updateStatistics();
+        showNotification('調味料が削除されました。', 'info');
+    }
+}
+
+// 期限までの日数を計算
+function getDaysUntilExpiry(expiryDate) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const expiry = new Date(expiryDate);
+    expiry.setHours(0, 0, 0, 0);
+    const diffTime = expiry - today;
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    return diffDays;
+}
+
+// 期限の状態を取得
+function getExpiryStatus(expiryDate) {
+    const days = getDaysUntilExpiry(expiryDate);
+    if (days < 0) return 'expired';
+    if (days <= 30) return 'warning';
+    return 'safe';
+}
+
+// 調味料を表示
+function displaySeasonings(seasoningsToShow = seasonings) {
+    // フィルタリング
+    let filteredSeasonings = seasoningsToShow;
+    if (currentFilter !== 'all') {
+        filteredSeasonings = seasoningsToShow.filter(s =>
+            getExpiryStatus(s.expiryDate) === currentFilter
+        );
+    }
+
+    // 期限順にソート（期限切れ・期限間近を優先）
+    filteredSeasonings.sort((a, b) => {
+        const daysA = getDaysUntilExpiry(a.expiryDate);
+        const daysB = getDaysUntilExpiry(b.expiryDate);
+        return daysA - daysB;
+    });
+
+    if (filteredSeasonings.length === 0) {
+        seasoningList.innerHTML = `
+            <div class="empty-state">
+                <h3>🧂 調味料がありません</h3>
+                <p>${currentFilter === 'all' ? '「調味料を追加」ボタンから調味料を登録してください' : 'このカテゴリに該当する調味料はありません'}</p>
+            </div>
+        `;
+        return;
+    }
+
+    seasoningList.innerHTML = filteredSeasonings.map(seasoning => {
+        const days = getDaysUntilExpiry(seasoning.expiryDate);
+        const status = getExpiryStatus(seasoning.expiryDate);
+        let daysText = '';
+        let statusClass = status;
+
+        if (days < 0) {
+            daysText = `${Math.abs(days)}日前に期限切れ`;
+        } else if (days === 0) {
+            daysText = '本日期限';
+        } else if (days === 1) {
+            daysText = '明日期限';
+        } else if (days <= 7) {
+            daysText = `あと${days}日`;
+        } else if (days <= 30) {
+            daysText = `あと${days}日`;
+        } else {
+            daysText = `あと${days}日`;
+        }
+
+        const quantityClass = seasoning.quantity <= 25 ? 'low' : seasoning.quantity <= 50 ? 'medium' : '';
+
+        return `
+            <div class="seasoning-card ${statusClass}" data-id="${seasoning.id}">
+                <div class="seasoning-header">
+                    <div class="seasoning-name">${escapeHtml(seasoning.name)}</div>
+                    <span class="seasoning-category">${escapeHtml(seasoning.category)}</span>
+                </div>
+
+                <div class="seasoning-details">
+                    <div class="detail-row">
+                        <span class="detail-label">賞味期限</span>
+                        <span class="detail-value expiry-date">
+                            ${new Date(seasoning.expiryDate).toLocaleDateString('ja-JP')}
+                            <span class="days-remaining ${statusClass}">${daysText}</span>
+                        </span>
+                    </div>
+
+                    ${seasoning.openedDate ? `
+                        <div class="detail-row">
+                            <span class="detail-label">開封日</span>
+                            <span class="detail-value">${new Date(seasoning.openedDate).toLocaleDateString('ja-JP')}</span>
+                        </div>
+                    ` : ''}
+
+                    <div class="detail-row">
+                        <span class="detail-label">残量</span>
+                        <span class="detail-value">${seasoning.quantity}%</span>
+                    </div>
+
+                    <div class="quantity-indicator">
+                        <div class="quantity-fill ${quantityClass}" style="width: ${seasoning.quantity}%"></div>
+                    </div>
+
+                    ${seasoning.location ? `
+                        <div class="detail-row">
+                            <span class="detail-label">保管場所</span>
+                            <span class="detail-value">${escapeHtml(seasoning.location)}</span>
+                        </div>
+                    ` : ''}
+
+                    ${seasoning.notes ? `
+                        <div class="detail-row">
+                            <span class="detail-label">メモ</span>
+                            <span class="detail-value" style="font-size: 0.85rem; font-weight: 400;">${escapeHtml(seasoning.notes)}</span>
+                        </div>
+                    ` : ''}
+                </div>
+
+                <div class="seasoning-actions">
+                    <button class="btn-edit-seasoning" onclick="openEditModal('${seasoning.id}')">
+                        編集
+                    </button>
+                    <button class="btn-delete-seasoning" onclick="deleteSeasoning('${seasoning.id}')">
+                        削除
+                    </button>
+                </div>
+            </div>
+        `;
+    }).join('');
+}
+
+// 統計情報を更新
+function updateStatistics() {
+    let expired = 0;
+    let warning = 0;
+    let safe = 0;
+
+    seasonings.forEach(seasoning => {
+        const status = getExpiryStatus(seasoning.expiryDate);
+        if (status === 'expired') expired++;
+        else if (status === 'warning') warning++;
+        else if (status === 'safe') safe++;
+    });
+
+    expiredCount.textContent = expired;
+    warningCount.textContent = warning;
+    safeCount.textContent = safe;
+    totalCount.textContent = seasonings.length;
+}
+
+// 期限切れの調味料をチェックして通知
+function checkExpiredSeasonings() {
+    const expiredItems = seasonings.filter(s => getExpiryStatus(s.expiryDate) === 'expired');
+    const warningItems = seasonings.filter(s => getExpiryStatus(s.expiryDate) === 'warning');
+
+    if (expiredItems.length > 0) {
+        showNotification(`⚠️ ${expiredItems.length}個の調味料が期限切れです！`, 'warning');
+    } else if (warningItems.length > 0) {
+        showNotification(`📢 ${warningItems.length}個の調味料の期限が近づいています`, 'info');
+    }
+}
+
+// 通知表示
+function showNotification(message, type = 'info') {
+    const notification = document.createElement('div');
+    notification.style.cssText = `
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        padding: 1rem 1.5rem;
+        border-radius: 12px;
+        color: white;
+        font-weight: 500;
+        z-index: 2000;
+        animation: slideInRight 0.3s ease;
+        max-width: 350px;
+        box-shadow: 0 6px 20px rgba(0,0,0,0.15);
+    `;
+
+    const colors = {
+        success: 'linear-gradient(135deg, #26de81 0%, #4ecca3 100%)',
+        info: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        warning: 'linear-gradient(135deg, #ffa502 0%, #ffcc29 100%)',
+        error: 'linear-gradient(135deg, #ff4757 0%, #ff6b7a 100%)'
+    };
+
+    notification.style.background = colors[type] || colors.info;
+    notification.textContent = message;
+
+    document.body.appendChild(notification);
+
+    setTimeout(() => {
+        notification.style.animation = 'slideOutRight 0.3s ease';
+        setTimeout(() => {
+            document.body.removeChild(notification);
+        }, 300);
+    }, 4000);
+}
+
+// HTMLエスケープ関数
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+// アニメーション用CSS（動的に追加）
+const style = document.createElement('style');
+style.textContent = `
+    @keyframes slideInRight {
+        from {
+            opacity: 0;
+            transform: translateX(100%);
+        }
+        to {
+            opacity: 1;
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes slideOutRight {
+        from {
+            opacity: 1;
+            transform: translateX(0);
+        }
+        to {
+            opacity: 0;
+            transform: translateX(100%);
+        }
+    }
+`;
+document.head.appendChild(style);


### PR DESCRIPTION
## 概要
調味料の賞味期限を管理できる新しいページを追加しました。

## 関連Issue
Closes #4

## 実装内容
### 新機能
- 🧂 **調味料管理専用ページ**の作成
  - `seasoning.html`, `seasoning.js`, `seasoning.css`を新規作成
  
### 主な機能
- **調味料の登録・編集・削除**
  - 調味料名、カテゴリ、賞味期限、開封日、残量、保管場所、メモを管理
  
- **期限管理**
  - 期限切れ（赤）
  - 期限間近/30日以内（オレンジ）
  - 期限まで余裕（緑）
  
- **フィルター機能**
  - すべて表示
  - 期限切れのみ
  - 期限間近のみ
  - 期限まで余裕のみ
  
- **統計情報ダッシュボード**
  - 各状態の調味料数を一目で確認
  
- **通知機能**
  - 期限切れ・期限間近の調味料がある場合に自動通知
  
- **データ永続化**
  - ローカルストレージを使用してデータを保存

### UI/UX改善
- 期限までの日数を分かりやすく表示（「あと〇日」「〇日前に期限切れ」）
- 残量を視覚的にプログレスバーで表示
- レスポンシブデザイン対応

### ナビゲーション
- レシピ一覧ページに「調味料管理」ボタンを追加
- 調味料管理ページから「レシピ一覧へ」ボタンで戻れる

## スクリーンショット
調味料管理ページでは以下の機能が利用できます：
- 調味料の追加・編集・削除
- 期限状態によるフィルタリング
- 統計情報の確認
- 期限切れ・期限間近の通知

## テスト項目
- [x] 調味料の追加機能が正常に動作する
- [x] 編集・削除機能が正常に動作する
- [x] フィルター機能が正常に動作する
- [x] 期限計算が正確である
- [x] ローカルストレージへの保存・読み込みが正常
- [x] レスポンシブデザインが機能する
- [x] ページ間のナビゲーションが正常

🤖 Generated with [Claude Code](https://claude.ai/code)